### PR TITLE
Feature/jm/ios 7664 use default data init

### DIFF
--- a/Lighthouse.xcodeproj/project.pbxproj
+++ b/Lighthouse.xcodeproj/project.pbxproj
@@ -812,9 +812,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 012A954B1C4EFD5E000A4ECB /* Build configuration list for PBXNativeTarget "Lighthouse" */;
 			buildPhases = (
+				012A95371C4EFD5E000A4ECB /* Headers */,
 				012A95351C4EFD5E000A4ECB /* Sources */,
 				012A95361C4EFD5E000A4ECB /* Frameworks */,
-				012A95371C4EFD5E000A4ECB /* Headers */,
 				012A95381C4EFD5E000A4ECB /* Resources */,
 			);
 			buildRules = (

--- a/Lighthouse/LHUpdateHandlerDriver.h
+++ b/Lighthouse/LHUpdateHandlerDriver.h
@@ -21,9 +21,11 @@ typedef _Nonnull id (^LHDriverDataUpdateBlock)(id data, __kindof id<LHCommand> c
 
 @interface LHUpdateHandlerDriver : NSObject <LHDriver>
 
-@property (nonatomic, copy, nullable) LHDriverDataInitBlock defaultDataInitBlock;
+@property (nonatomic, copy) LHDriverDataInitBlock defaultDataInitBlock;
 
-- (instancetype)initWithDefaultDataInitBlock:(nullable LHDriverDataInitBlock)block NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithDefaultDataInitBlock:(LHDriverDataInitBlock)block NS_DESIGNATED_INITIALIZER;
 
 - (void)bindCommandClass:(Class)commandClass toDataInitBlock:(LHDriverDataInitBlock)block NS_REFINED_FOR_SWIFT;
 

--- a/Lighthouse/LHUpdateHandlerDriver.m
+++ b/Lighthouse/LHUpdateHandlerDriver.m
@@ -26,10 +26,6 @@
 
 #pragma mark - Init
 
-- (instancetype)init {
-    return [self initWithDefaultDataInitBlock:nil];
-}
-
 - (instancetype)initWithDefaultDataInitBlock:(LHDriverDataInitBlock)block {
     self = [super init];
     if (!self) return nil;

--- a/Lighthouse/LHUpdateHandlerDriver.swift
+++ b/Lighthouse/LHUpdateHandlerDriver.swift
@@ -11,9 +11,12 @@ public extension LHUpdateHandlerDriver {
 
     static func driver<Command>(
         for commandType: Command.Type,
-        with dataInitClosure: @escaping DataInitClosure<Command>
+        with dataInitClosure: @escaping DataInitClosure<Command>,
+        defaultViewControllerProvider: @autoclosure @escaping () -> UIViewController
     ) -> LHUpdateHandlerDriver where Command: LHCommand {
-        let driver = LHUpdateHandlerDriver()
+        let driver = LHUpdateHandlerDriver(defaultDataInitBlock: { _, _ in
+            defaultViewControllerProvider()
+        })
 
         driver.bind(commandType) { command, updateBus in
             guard let command = command as? Command else {


### PR DESCRIPTION
Форсирую использование `defaultDataInit`.
Теперь нельзя создать `LHUpdateHandlerDriver`, не указав его.