### PR TITLE
Avoid a crash

### DIFF
--- a/Lighthouse.xcodeproj/project.pbxproj
+++ b/Lighthouse.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		7CC84D6023275891001FFE6A /* LHNavigationControllerTransitionOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CC84D5E23275891001FFE6A /* LHNavigationControllerTransitionOptions.m */; };
 		7CFC39092C5794FF00144A65 /* LHAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CFC39072C5794FF00144A65 /* LHAssert.h */; };
 		7CFC390A2C5794FF00144A65 /* LHAssert.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CFC39082C5794FF00144A65 /* LHAssert.m */; };
+		7CFC390D2C5803F900144A65 /* NSError+LHUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CFC390B2C5803F900144A65 /* NSError+LHUtils.h */; };
+		7CFC390E2C5803F900144A65 /* NSError+LHUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CFC390C2C5803F900144A65 /* NSError+LHUtils.m */; };
 		ACC5686D1F18C45300602DEA /* LHLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC5686B1F18C45300602DEA /* LHLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ACC5686E1F18C45300602DEA /* LHLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = ACC5686C1F18C45300602DEA /* LHLogger.m */; };
 		ACC568721F18C90F00602DEA /* LHLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC568701F18C90E00602DEA /* LHLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -304,6 +306,8 @@
 		7CC84D5E23275891001FFE6A /* LHNavigationControllerTransitionOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LHNavigationControllerTransitionOptions.m; sourceTree = "<group>"; };
 		7CFC39072C5794FF00144A65 /* LHAssert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LHAssert.h; sourceTree = "<group>"; };
 		7CFC39082C5794FF00144A65 /* LHAssert.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LHAssert.m; sourceTree = "<group>"; };
+		7CFC390B2C5803F900144A65 /* NSError+LHUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+LHUtils.h"; sourceTree = "<group>"; };
+		7CFC390C2C5803F900144A65 /* NSError+LHUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+LHUtils.m"; sourceTree = "<group>"; };
 		ACC5686B1F18C45300602DEA /* LHLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LHLogger.h; sourceTree = "<group>"; };
 		ACC5686C1F18C45300602DEA /* LHLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LHLogger.m; sourceTree = "<group>"; };
 		ACC568701F18C90E00602DEA /* LHLogLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LHLogLevel.h; sourceTree = "<group>"; };
@@ -474,6 +478,8 @@
 				014C9F141C96F94E00D35950 /* LHMacro.h */,
 				7CFC39072C5794FF00144A65 /* LHAssert.h */,
 				7CFC39082C5794FF00144A65 /* LHAssert.m */,
+				7CFC390B2C5803F900144A65 /* NSError+LHUtils.h */,
+				7CFC390C2C5803F900144A65 /* NSError+LHUtils.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -802,6 +808,7 @@
 				01DBF2FC1C4EFEB00034783C /* LHDriverChannelImpl.h in Headers */,
 				01DBF2FD1C4EFEB00034783C /* LHUpdateBusImpl.h in Headers */,
 				01DBF2EA1C4EFE700034783C /* LHCompositeDriver.h in Headers */,
+				7CFC390D2C5803F900144A65 /* NSError+LHUtils.h in Headers */,
 				01DBF2D51C4EFE700034783C /* LHStackNodeChildrenState.h in Headers */,
 				01B3918D1C888FFD00579C2B /* LHRouterState.h in Headers */,
 				01DBF2DC1C4EFE700034783C /* LHViewControllerDriverHelpers.h in Headers */,
@@ -962,6 +969,7 @@
 				01D57AB41C547557008E4EB5 /* LHTabNodeChildrenState.m in Sources */,
 				012A956D1C4EFD9A000A4ECB /* LHBlockTask.m in Sources */,
 				012A956E1C4EFD9A000A4ECB /* LHNodeUpdateTask.m in Sources */,
+				7CFC390E2C5803F900144A65 /* NSError+LHUtils.m in Sources */,
 				015A4F9C1C67A49400F950B3 /* LHModalTransitionData.m in Sources */,
 				012A956F1C4EFD9A000A4ECB /* LHCommandNodeUpdateTask.m in Sources */,
 				012A95701C4EFD9A000A4ECB /* LHManualNodeUpdateTask.m in Sources */,

--- a/Lighthouse.xcodeproj/project.pbxproj
+++ b/Lighthouse.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		74F2A4AA26676E5D00CD86B0 /* LHUpdateHandlerDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F2A4A926676E5D00CD86B0 /* LHUpdateHandlerDriver.swift */; };
 		7CC84D5F23275891001FFE6A /* LHNavigationControllerTransitionOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CC84D5D23275891001FFE6A /* LHNavigationControllerTransitionOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7CC84D6023275891001FFE6A /* LHNavigationControllerTransitionOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CC84D5E23275891001FFE6A /* LHNavigationControllerTransitionOptions.m */; };
+		7CFC39092C5794FF00144A65 /* LHAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CFC39072C5794FF00144A65 /* LHAssert.h */; };
+		7CFC390A2C5794FF00144A65 /* LHAssert.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CFC39082C5794FF00144A65 /* LHAssert.m */; };
 		ACC5686D1F18C45300602DEA /* LHLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC5686B1F18C45300602DEA /* LHLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ACC5686E1F18C45300602DEA /* LHLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = ACC5686C1F18C45300602DEA /* LHLogger.m */; };
 		ACC568721F18C90F00602DEA /* LHLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = ACC568701F18C90E00602DEA /* LHLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -300,6 +302,8 @@
 		74F2A4A926676E5D00CD86B0 /* LHUpdateHandlerDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LHUpdateHandlerDriver.swift; sourceTree = "<group>"; };
 		7CC84D5D23275891001FFE6A /* LHNavigationControllerTransitionOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LHNavigationControllerTransitionOptions.h; sourceTree = "<group>"; };
 		7CC84D5E23275891001FFE6A /* LHNavigationControllerTransitionOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LHNavigationControllerTransitionOptions.m; sourceTree = "<group>"; };
+		7CFC39072C5794FF00144A65 /* LHAssert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LHAssert.h; sourceTree = "<group>"; };
+		7CFC39082C5794FF00144A65 /* LHAssert.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LHAssert.m; sourceTree = "<group>"; };
 		ACC5686B1F18C45300602DEA /* LHLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LHLogger.h; sourceTree = "<group>"; };
 		ACC5686C1F18C45300602DEA /* LHLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LHLogger.m; sourceTree = "<group>"; };
 		ACC568701F18C90E00602DEA /* LHLogLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LHLogLevel.h; sourceTree = "<group>"; };
@@ -468,6 +472,8 @@
 				0F0DD0621E30F8EA005C6C47 /* NSArray+LHUtils.h */,
 				0F0DD0631E30F8EA005C6C47 /* NSArray+LHUtils.m */,
 				014C9F141C96F94E00D35950 /* LHMacro.h */,
+				7CFC39072C5794FF00144A65 /* LHAssert.h */,
+				7CFC39082C5794FF00144A65 /* LHAssert.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -733,6 +739,7 @@
 				014C9F091C9620AF00D35950 /* LHRouterResumeToken.h in Headers */,
 				01DBF2D41C4EFE700034783C /* LHStackNode.h in Headers */,
 				01DBF2D71C4EFE700034783C /* LHTabNode.h in Headers */,
+				7CFC39092C5794FF00144A65 /* LHAssert.h in Headers */,
 				01DBF2D81C4EFE700034783C /* LHNode.h in Headers */,
 				0F5FC6F71DCCB567009596D4 /* LHRouteHint.h in Headers */,
 				01DBF2D91C4EFE700034783C /* LHNodeModelState.h in Headers */,
@@ -946,6 +953,7 @@
 				0F5FC6F01DCBE158009596D4 /* LHGraphEdge.m in Sources */,
 				015A4F931C67014F00F950B3 /* LHContainerTransitionStyleRegistry.m in Sources */,
 				015A4FAB1C67FF5700F950B3 /* LHTransitionContext.m in Sources */,
+				7CFC390A2C5794FF00144A65 /* LHAssert.m in Sources */,
 				012A95681C4EFD9A000A4ECB /* LHDescriptionHelpers.m in Sources */,
 				015A4FA71C67D77F00F950B3 /* LHContainerTransitionData.m in Sources */,
 				012A956A1C4EFD9A000A4ECB /* LHNodeData.m in Sources */,
@@ -1042,7 +1050,6 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = LighthouseTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pixty.LighthouseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1054,7 +1061,6 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = LighthouseTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pixty.LighthouseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1105,7 +1111,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1150,7 +1156,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/Lighthouse/LHAssert.h
+++ b/Lighthouse/LHAssert.h
@@ -1,0 +1,85 @@
+//
+//  LHAssert.h
+//  Lighthouse
+//
+//  Created by Artem Starosvetskiy on 29.07.2024.
+//  Copyright © 2024 Pixty. All rights reserved.
+//
+
+#import "LHMacro.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if DEBUG
+
+#if TARGET_OS_SIMULATOR
+
+@interface LHAssertionHandler : NSObject
+
++ (void)handleFailureInFunction:(NSString *)functionName
+                           file:(NSString *)fileName
+                     lineNumber:(NSInteger)line
+                    description:(nullable NSString *)format,... NS_FORMAT_FUNCTION(4,5);
+
+@end
+
+/// Assertion macros, such as `LHAssert`, are used to evaluate a condition, and if the condition evaluates to false, the macros pass
+/// a string to an assertion handler describing the failure. When invoked, an assertion handler prints an error message that
+/// includes the method and class (or function) containing the assertion.
+///
+/// In debug builds (`-D DEBUG=1`), `LHAssertionHandler` is used.
+///
+/// @note When the application is run under debugger control, `LHAssertionHandler`
+/// pauses execution, but doesn't interrupt it.
+///
+/// In release builds, `LHAssert` is mapped to `NSCAssert`, e.g. `NSAssertionHandler` is used.
+///
+/// @note Unlike `LHAssertionHandler`, `NSAssertionHandler` raises `NSInternalInconsistencyException`. Thus, execution can't be continued.
+#define _LHAssert(condition_, description_...) \
+    do { \
+        __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
+        if (__builtin_expect(!(condition_), 0)) { \
+            NSString *__assert_fn__ = [NSString stringWithUTF8String:__PRETTY_FUNCTION__]; \
+            __assert_fn__ = __assert_fn__ ? __assert_fn__ : @"<Unknown Function>"; \
+            NSString *__assert_file__ = [NSString stringWithUTF8String:__FILE__]; \
+            __assert_file__ = __assert_file__ ? __assert_file__ : @"<Unknown File>"; \
+            [LHAssertionHandler handleFailureInFunction:__assert_fn__ \
+                                                   file:__assert_file__ \
+                                             lineNumber:__LINE__ \
+                                            description:LH_IF_EMPTY(description_)(nil)(description_)]; \
+        } \
+        __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS \
+    } while(0)
+
+//#undef NSAssert
+//#undef NSCAssert
+
+//#undef NSParameterAssert
+//#undef NSCParameterAssert
+
+//extern void NSAssert(BOOL condition, NSString *format, ...) NS_FORMAT_FUNCTION(2, 3) __attribute__((unavailable("Use `LHAssert` instead")));
+//extern void NSCAssert(BOOL condition, NSString *format, ...) NS_FORMAT_FUNCTION(2, 3) __attribute__((unavailable("Use `LHAssert` instead")));
+
+//extern void NSParameterAssert(BOOL condition) __attribute__((unavailable("Use `LHParameterAssert` instead")));
+//extern void NSCParameterAssert(BOOL condition) __attribute__((unavailable("Use `LHParameterAssert` instead")));
+
+#else // !TARGET_OS_SIMULATOR
+
+#define _LHAssert(condition_, description_...) do {} while (0)
+
+#endif // TARGET_OS_SIMULATOR
+
+#define LHParameterAssert(condition_) LHAssert((condition_), @"Invalid parameter not satisfying: %@", @#condition_)
+
+#else // !DEBUG
+
+#define _LHAssert(condition, description_...) NSCAssert((condition_), LH_IF_EMPTY(description_)(nil)(description_))
+#define LHParameterAssert(condition_) NSCParameterAssert((condition_))
+
+#endif // DEBUG
+
+#define LHAssert(/*condition, description, ...*/ ...) _LHAssert(__VA_ARGS__)
+
+#define LHAssertionFailure(description_...) _LHAssert(NO, ##description_);
+
+NS_ASSUME_NONNULL_END

--- a/Lighthouse/LHAssert.h
+++ b/Lighthouse/LHAssert.h
@@ -51,18 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
         __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS \
     } while(0)
 
-//#undef NSAssert
-//#undef NSCAssert
-
-//#undef NSParameterAssert
-//#undef NSCParameterAssert
-
-//extern void NSAssert(BOOL condition, NSString *format, ...) NS_FORMAT_FUNCTION(2, 3) __attribute__((unavailable("Use `LHAssert` instead")));
-//extern void NSCAssert(BOOL condition, NSString *format, ...) NS_FORMAT_FUNCTION(2, 3) __attribute__((unavailable("Use `LHAssert` instead")));
-
-//extern void NSParameterAssert(BOOL condition) __attribute__((unavailable("Use `LHParameterAssert` instead")));
-//extern void NSCParameterAssert(BOOL condition) __attribute__((unavailable("Use `LHParameterAssert` instead")));
-
 #else // !TARGET_OS_SIMULATOR
 
 #define _LHAssert(condition_, description_...) do {} while (0)

--- a/Lighthouse/LHAssert.m
+++ b/Lighthouse/LHAssert.m
@@ -1,0 +1,82 @@
+//
+//  LHAssert.m
+//  Lighthouse
+//
+//  Created by Artem Starosvetskiy on 29.07.2024.
+//  Copyright © 2024 Pixty. All rights reserved.
+//
+
+#import "LHAssert.h"
+#import <sys/sysctl.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if TARGET_OS_SIMULATOR
+
+static BOOL LHAssertIsDebuggerAttached(void) {
+    // See http://developer.apple.com/library/mac/#qa/qa1361/_index.html
+    int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
+    struct kinfo_proc info;
+    size_t size = sizeof(info);
+    return sysctl(mib, LH_LENGTH_OF(mib), &info, &size, NULL, 0) == 0 ? LH_HAS_FLAGS(info.kp_proc.p_flag, P_TRACED) : NO;
+}
+
+// LHAssertDebugBreak is same as __builtin_trap, but allows resuming
+// execution after the break.
+#if __i386__ || __x86_64__
+#define LHAssertDebugBreak() asm("int3")
+#elif __arm__
+#define LHAssertDebugBreak()                              \
+  asm("mov r0, %0    \n" /* PID                        */ \
+      "mov r1, 0x11  \n" /* SIGSTOP                    */ \
+      "mov r12, 0x25 \n" /* syscall kill               */ \
+      "svc 0x80      \n" /* software interrupt         */ \
+      "mov r0, r0    \n" /* nop to pause debugger here */ \
+      ::"r"(getpid())                                     \
+      : "r0", "r1", "r12", "memory")
+#elif __arm64__
+#define LHAssertDebugBreak()                    \
+  asm("mov x0, %x0   \n" /* PID                        */ \
+      "mov x1, 0x11  \n" /* SIGSTOP                    */ \
+      "mov x16, 0x25 \n" /* syscall kill               */ \
+      "svc 0x80      \n" /* software interrupt         */ \
+      "mov x0, x0    \n" /* nop to pause debugger here */ \
+      ::"r"(getpid())                                     \
+      : "x0", "x1", "x16", "memory")
+#else
+#error "Unsupported architecture."
+#endif  // __i386__ || __x86_64__
+
+@implementation LHAssertionHandler
+
++ (void)handleFailureInFunction:(NSString *)functionName
+                           file:(NSString *)fileName
+                     lineNumber:(NSInteger)line
+                    description:(nullable NSString *)format,... NS_FORMAT_FUNCTION(4,5) {
+    let message = [NSMutableString stringWithFormat:@"*** Assertion failure in %@, %@:%lu", functionName, fileName, (unsigned long)line];
+
+    if (format) {
+        va_list args;
+        va_start(args, format);
+
+        [message appendString:@", reason: '"];
+        [message appendString:[[NSString alloc] initWithFormat:format arguments:args]];
+        [message appendString:@"'"];
+
+        va_end(args);
+    }
+
+    [LHSharedLogger() logMessageWithLevel:LHLogLevelError format:@"%@", message];
+
+    if (LHAssertIsDebuggerAttached()) {
+        LHAssertDebugBreak();
+    } else {
+        // Do nothing. We don't want to crash when the debugger is not attached.
+    }
+}
+
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/Lighthouse/LHLogLevel.m
+++ b/Lighthouse/LHLogLevel.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static LHLogLevel LHCurrentAcceptedLogLevel = LHLogLevelInfo;
 
-LHLogLevel LHAcceptedLogLevel() {
+LHLogLevel LHAcceptedLogLevel(void) {
     NSCAssert(NSThread.currentThread.isMainThread, @"%s should be called from the main thread.", __PRETTY_FUNCTION__);
 
     return LHCurrentAcceptedLogLevel;

--- a/Lighthouse/LHLogger.m
+++ b/Lighthouse/LHLogger.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static id<LHLogger> LHCurrentSharedLogger;
 
-id<LHLogger> LHSharedLogger() {
+id<LHLogger> LHSharedLogger(void) {
     NSCAssert(NSThread.currentThread.isMainThread, @"%s should be called from the main thread.", __PRETTY_FUNCTION__);
     
     if (!LHCurrentSharedLogger) {

--- a/Lighthouse/LHMacro.h
+++ b/Lighthouse/LHMacro.h
@@ -8,6 +8,135 @@
 
 #import <Foundation/Foundation.h>
 
+#define let \
+    const __auto_type
+
+#define var \
+    __auto_type
+
 #define LHObjectKeyPath(OBJ, PATH)  @(((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
 
 #define LHClassKeyPath(CLS, PATH)  @(((void)(NO && ((void)[CLS new].PATH, NO)), # PATH))
+
+#define LH_LENGTH_OF(array_) ({ sizeof((array_)) / sizeof((array_)[0]); })
+
+#define LH_ADD_FLAGS(value_, flags_) ((value_) | (flags_))
+#define LH_REMOVE_FLAGS(value_, flags_) ((value_) & ~(flags_))
+#define LH_HAS_FLAGS(value_, flags_) (((value_) & (flags_)) == (flags_))
+
+// LH_IF_EMPTY
+
+#define LH_IF_EMPTY(...) \
+    LH_IF_EQ(1, LH_ARGCOUNT(0, ##__VA_ARGS__))
+
+// LH_CONCAT
+
+#define LH_CONCAT(a_, b_) \
+    LH_CONCAT_(a_, b_)
+
+#define LH_CONCAT_(a_, b_) a_ ## b_
+
+// LH_AT
+
+#define LH_AT(N, ...) \
+    LH_CONCAT(LH_AT, N)(__VA_ARGS__)
+
+#define LH_AT0(...) LH_HEAD(__VA_ARGS__)
+#define LH_AT1(_0, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT2(_0, _1, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT3(_0, _1, _2, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT4(_0, _1, _2, _3, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT5(_0, _1, _2, _3, _4, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT6(_0, _1, _2, _3, _4, _5, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT7(_0, _1, _2, _3, _4, _5, _6, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT8(_0, _1, _2, _3, _4, _5, _6, _7, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT9(_0, _1, _2, _3, _4, _5, _6, _7, _8, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT10(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT11(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT12(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT13(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT14(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT15(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT16(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT17(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT18(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT19(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, ...) LH_HEAD(__VA_ARGS__)
+#define LH_AT20(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, ...) LH_HEAD(__VA_ARGS__)
+
+// LH_ARGCOUNT
+
+#define LH_ARGCOUNT(...) \
+    LH_AT(20, __VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+// LH_HEAD
+
+#define LH_HEAD(...) \
+    LH_HEAD_(__VA_ARGS__, 0)
+
+#define LH_HEAD_(first_, ...) first_
+
+// LH_TAIL
+
+#define LH_TAIL_(first_, ...) __VA_ARGS__
+
+#define LH_TAIL(...) \
+    LH_TAIL_(__VA_ARGS__)
+
+// LH_DEC
+
+#define LH_DEC(value_) \
+    LH_AT(value_, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+
+#define LH_CONSUME_(...)
+#define LH_EXPAND_(...) __VA_ARGS__
+
+// LH_IF_EQ
+
+#define LH_IF_EQ(a_, b_) \
+    LH_CONCAT(LH_IF_EQ, a_)(b_)
+
+#define LH_IF_EQ0(value_) \
+    LH_CONCAT(LH_IF_EQ0_, value_)
+
+#define LH_IF_EQ0_0(...) __VA_ARGS__ LH_CONSUME_
+#define LH_IF_EQ0_1(...) LH_EXPAND_
+#define LH_IF_EQ0_2(...) LH_EXPAND_
+#define LH_IF_EQ0_3(...) LH_EXPAND_
+#define LH_IF_EQ0_4(...) LH_EXPAND_
+#define LH_IF_EQ0_5(...) LH_EXPAND_
+#define LH_IF_EQ0_6(...) LH_EXPAND_
+#define LH_IF_EQ0_7(...) LH_EXPAND_
+#define LH_IF_EQ0_8(...) LH_EXPAND_
+#define LH_IF_EQ0_9(...) LH_EXPAND_
+#define LH_IF_EQ0_10(...) LH_EXPAND_
+#define LH_IF_EQ0_11(...) LH_EXPAND_
+#define LH_IF_EQ0_12(...) LH_EXPAND_
+#define LH_IF_EQ0_13(...) LH_EXPAND_
+#define LH_IF_EQ0_14(...) LH_EXPAND_
+#define LH_IF_EQ0_15(...) LH_EXPAND_
+#define LH_IF_EQ0_16(...) LH_EXPAND_
+#define LH_IF_EQ0_17(...) LH_EXPAND_
+#define LH_IF_EQ0_18(...) LH_EXPAND_
+#define LH_IF_EQ0_19(...) LH_EXPAND_
+#define LH_IF_EQ0_20(...) LH_EXPAND_
+
+#define LH_IF_EQ1(VALUE) LH_IF_EQ0(LH_DEC(VALUE))
+#define LH_IF_EQ2(VALUE) LH_IF_EQ1(LH_DEC(VALUE))
+#define LH_IF_EQ3(VALUE) LH_IF_EQ2(LH_DEC(VALUE))
+#define LH_IF_EQ4(VALUE) LH_IF_EQ3(LH_DEC(VALUE))
+#define LH_IF_EQ5(VALUE) LH_IF_EQ4(LH_DEC(VALUE))
+#define LH_IF_EQ6(VALUE) LH_IF_EQ5(LH_DEC(VALUE))
+#define LH_IF_EQ7(VALUE) LH_IF_EQ6(LH_DEC(VALUE))
+#define LH_IF_EQ8(VALUE) LH_IF_EQ7(LH_DEC(VALUE))
+#define LH_IF_EQ9(VALUE) LH_IF_EQ8(LH_DEC(VALUE))
+#define LH_IF_EQ10(VALUE) LH_IF_EQ9(LH_DEC(VALUE))
+#define LH_IF_EQ11(VALUE) LH_IF_EQ10(LH_DEC(VALUE))
+#define LH_IF_EQ12(VALUE) LH_IF_EQ11(LH_DEC(VALUE))
+#define LH_IF_EQ13(VALUE) LH_IF_EQ12(LH_DEC(VALUE))
+#define LH_IF_EQ14(VALUE) LH_IF_EQ13(LH_DEC(VALUE))
+#define LH_IF_EQ15(VALUE) LH_IF_EQ14(LH_DEC(VALUE))
+#define LH_IF_EQ16(VALUE) LH_IF_EQ15(LH_DEC(VALUE))
+#define LH_IF_EQ17(VALUE) LH_IF_EQ16(LH_DEC(VALUE))
+#define LH_IF_EQ18(VALUE) LH_IF_EQ17(LH_DEC(VALUE))
+#define LH_IF_EQ19(VALUE) LH_IF_EQ18(LH_DEC(VALUE))
+#define LH_IF_EQ20(VALUE) LH_IF_EQ19(LH_DEC(VALUE))

--- a/Lighthouse/LHRouter.h
+++ b/Lighthouse/LHRouter.h
@@ -37,6 +37,8 @@ typedef void (^LHRouterCompletionBlock)(void);
 
 @property (nonatomic, weak, nullable) id<LHRouterDelegate> delegate;
 
+@property (nonatomic, copy, nullable) void(^nonFatalErrorHandler)(NSError *error);
+
 
 - (instancetype)initWithRootNode:(id<LHNode>)rootNode
                    driverFactory:(id<LHDriverFactory>)driverFactory

--- a/Lighthouse/LHRouter.m
+++ b/Lighthouse/LHRouter.m
@@ -236,8 +236,14 @@
 #pragma mark - LHNodeDataStorageDelegate
 
 - (void)nodeDataStorage:(LHNodeDataStorage *)storage didCreateData:(LHNodeData *)data forNode:(id<LHNode>)node {
-    NSArray<id<LHDriver>> *drivers = data.drivers ?: @[];
-    data.drivers = [drivers arrayByAddingObject:[self createDriverForNode:node]];
+    let existingDrivers = data.drivers ?: @[];
+    let newDriver = [self createDriverForNode:node];
+
+    LHAssert(newDriver != nil, @"Driver for node %@ not provided", node.label);
+
+    if (newDriver) {
+        data.drivers = [existingDrivers arrayByAddingObject:newDriver];
+    }
 }
 
 - (id<LHDriver>)createDriverForNode:(id<LHNode>)node {

--- a/Lighthouse/LHRouter.m
+++ b/Lighthouse/LHRouter.m
@@ -240,17 +240,15 @@
     let existingDrivers = data.drivers ?: @[];
     let newDriver = [self createDriverForNode:node];
 
-    if (newDriver == nil) {
+    if (newDriver) {
+        data.drivers = [existingDrivers arrayByAddingObject:newDriver];
+    } else {
         LHAssertionFailure(@"Driver for node %@ not provided", node.label);
-        
+
         if (self.nonFatalErrorHandler) {
             let error = [NSError lh_nonFatalErrorWithDescription:@"Driver for node %@ not provided", node.label];
             self.nonFatalErrorHandler(error);
         }
-    }
-
-    if (newDriver) {
-        data.drivers = [existingDrivers arrayByAddingObject:newDriver];
     }
 }
 

--- a/Lighthouse/LHRouter.m
+++ b/Lighthouse/LHRouter.m
@@ -27,6 +27,7 @@
 #import "LHManualNodeUpdateTask.h"
 #import "LHDriverChannelImpl.h"
 #import "LHMacro.h"
+#import "NSError+LHUtils.h"
 
 @interface LHRouter () <LHNodeDataStorageDelegate>
 
@@ -239,7 +240,14 @@
     let existingDrivers = data.drivers ?: @[];
     let newDriver = [self createDriverForNode:node];
 
-    LHAssert(newDriver != nil, @"Driver for node %@ not provided", node.label);
+    if (newDriver == nil) {
+        LHAssertionFailure(@"Driver for node %@ not provided", node.label);
+        
+        if (self.nonFatalErrorHandler) {
+            let error = [NSError lh_nonFatalErrorWithDescription:@"Driver for node %@ not provided", node.label];
+            self.nonFatalErrorHandler(error);
+        }
+    }
 
     if (newDriver) {
         data.drivers = [existingDrivers arrayByAddingObject:newDriver];

--- a/Lighthouse/LHUpdateHandlerDriver.swift
+++ b/Lighthouse/LHUpdateHandlerDriver.swift
@@ -18,14 +18,7 @@ public extension LHUpdateHandlerDriver {
             defaultViewControllerProvider()
         })
 
-        driver.bind(commandType) { command, updateBus in
-            guard let command = command as? Command else {
-                assertionFailure()
-                return nil
-            }
-
-            return dataInitClosure(command, updateBus)
-        }
+        driver.bind(commandType, to: dataInitClosure)
 
         return driver
     }

--- a/Lighthouse/Lighthouse-PrefixHeader.pch
+++ b/Lighthouse/Lighthouse-PrefixHeader.pch
@@ -7,4 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "LHAssert.h"
 #import "LHLogger.h"
+#import "LHMacro.h"

--- a/Lighthouse/NSError+LHUtils.h
+++ b/Lighthouse/NSError+LHUtils.h
@@ -1,0 +1,19 @@
+//
+//  NSError+LHUtils.h
+//  Lighthouse
+//
+//  Created by Artem Starosvetskiy on 29.07.2024.
+//  Copyright © 2024 Pixty. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSError (LHUtils)
+
++ (instancetype)lh_nonFatalErrorWithDescription:(NSString *)description, ...;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Lighthouse/NSError+LHUtils.m
+++ b/Lighthouse/NSError+LHUtils.m
@@ -1,0 +1,30 @@
+//
+//  NSError+LHUtils.m
+//  Lighthouse
+//
+//  Created by Artem Starosvetskiy on 29.07.2024.
+//  Copyright © 2024 Pixty. All rights reserved.
+//
+
+#import "NSError+LHUtils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation NSError (LHUtils)
+
++ (instancetype)lh_nonFatalErrorWithDescription:(NSString *)description, ... {
+    va_list args;
+    va_start(args, description);
+
+    description = [[NSString alloc] initWithFormat:description arguments:args];
+
+    va_end(args);
+
+    return [NSError errorWithDomain:@"Lighthouse" code:-1 userInfo:@{
+        NSLocalizedDescriptionKey: description,
+    }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Наблюдаются падения ([пример](https://console.firebase.google.com/u/0/project/aga-1252/crashlytics/app/ios:com.joom.joom/issues/6b736f8f3ff11215f10b58fa7a236c7c?hl=ru&time=last-seven-days&types=crash&versions=4.43.0%20(13107)&sessionEventKey=3d226694429d413eadfcd6d8d3ced54b_1973938648287888620)) из-за того, что для какого-то узла не зарегистрирована фабрика `LHDriver`. Наверное, это нештатная ситуация (пока изучаю, что происходит в приложении). Но я решил превентивно подпереть это падение в Lighthouse. 